### PR TITLE
Fix key for remote identity in Android profile

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,6 @@
 name: docs
 title: strongSwan Docs
-version: 5.9
+version: '6.0'
+prerelease: Beta
 nav:
         - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/config/IKEv1.adoc
+++ b/docs/modules/ROOT/pages/config/IKEv1.adoc
@@ -1,6 +1,6 @@
 = IKEv1 Configuration Examples
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Remote Access
 

--- a/docs/modules/ROOT/pages/config/IKEv1Stroke.adoc
+++ b/docs/modules/ROOT/pages/config/IKEv1Stroke.adoc
@@ -1,6 +1,6 @@
 = IKEv1 Legacy Configuration Examples
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Remote Access
 

--- a/docs/modules/ROOT/pages/config/IKEv2.adoc
+++ b/docs/modules/ROOT/pages/config/IKEv2.adoc
@@ -1,6 +1,6 @@
 = IKEv2 Configuration Examples
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Remote Access
 

--- a/docs/modules/ROOT/pages/config/IKEv2Sql.adoc
+++ b/docs/modules/ROOT/pages/config/IKEv2Sql.adoc
@@ -1,6 +1,6 @@
 = IKEv2 SQL Configuration Examples
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Remote Access
 

--- a/docs/modules/ROOT/pages/config/IKEv2Stroke.adoc
+++ b/docs/modules/ROOT/pages/config/IKEv2Stroke.adoc
@@ -1,6 +1,6 @@
 = IKEv2 Legacy Configuration Examples
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Remote Access
 

--- a/docs/modules/ROOT/pages/config/IPv6.adoc
+++ b/docs/modules/ROOT/pages/config/IPv6.adoc
@@ -1,7 +1,7 @@
 = IPv6 Configuration Examples
 :toc: left
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Site-to-Site
 

--- a/docs/modules/ROOT/pages/config/IPv6Stroke.adoc
+++ b/docs/modules/ROOT/pages/config/IPv6Stroke.adoc
@@ -1,7 +1,7 @@
 = IPv6 Legacy Configuration Examples
 :toc: left
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 
 == Site-to-Site
 

--- a/docs/modules/ROOT/pages/config/configExamplesNotes.adoc
+++ b/docs/modules/ROOT/pages/config/configExamplesNotes.adoc
@@ -1,6 +1,6 @@
 = Notes on Configuration Examples
 
-:RESULTS: https://www.strongswan.org/testing/testresults
+:RESULTS: https://www.strongswan.org/testing/testresults6
 :GITHUB:  https://github.com/strongswan/strongswan/tree/master
 :TESTS:   testing/tests
 

--- a/docs/modules/ROOT/pages/config/sqliteDbSchema.adoc
+++ b/docs/modules/ROOT/pages/config/sqliteDbSchema.adoc
@@ -1,6 +1,6 @@
 = SQLite Database Schema
 
-:TESTS:  https://www.strongswan.org/testing/testresults
+:TESTS:  https://www.strongswan.org/testing/testresults6
 :GITHUB: https://github.com/strongswan/strongswan/blob/master
 :SRC1:   src/pool/sqlite.sql
 :SRC2:   src/libstrongswan/utils/identification.h

--- a/docs/modules/ROOT/pages/features/hashAndUrl.adoc
+++ b/docs/modules/ROOT/pages/features/hashAndUrl.adoc
@@ -2,7 +2,7 @@
 
 :IETF:    https://datatracker.ietf.org/doc/html
 :RFC7296: {IETF}/rfc7296
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 :EX1:     {TESTS}/ikev2/rw-hash-and-url
 :EX2:     {TESTS}/ikev2-multi-ca/rw-hash-and-url
 

--- a/docs/modules/ROOT/pages/features/highAvailability.adoc
+++ b/docs/modules/ROOT/pages/features/highAvailability.adoc
@@ -2,7 +2,7 @@
 
 :CLUSTERIP: https://lwn.net/Articles/108078/
 :DOWNLOAD:  https://download.strongswan.org/testing/
-:TESTS:     https://www.strongswan.org/testing/testresults
+:TESTS:     https://www.strongswan.org/testing/testresults6
 :IPSECME:   https://datatracker.ietf.org/wg/ipsecme/about/
 :IETF:      https://datatracker.ietf.org/doc/html
 :RFC6027:   {IETF}/rfc6027

--- a/docs/modules/ROOT/pages/features/ietf.adoc
+++ b/docs/modules/ROOT/pages/features/ietf.adoc
@@ -283,7 +283,7 @@ kernel.
 |{IETF}/rfc8983[RFC 8983]:
  IKEv2 Notification Status Types for IPv4/IPv6 Coexistence
 
-|6.0
+|
 |{IETF}/rfc9242[RFC 9242]:
  Intermediate Exchange in the IKEv2 Protocol
 
@@ -291,7 +291,7 @@ kernel.
 |{IETF}/draft-ietf-ipsecme-labeled-ipsec[draft-ietf-ipsecme-labeled-ipsec]:
  Labeled IPsec Traffic Selector support for IKEv2
 
-|6.0
+|
 |{IETF}/draft-ietf-ipsecme-ikev2-multiple-ke[draft-ietf-ipsecme-ikev2-multiple-ke]:
  Multiple Key Exchanges in IKEv2
 
@@ -534,6 +534,18 @@ Algorithm Identifiers for EdDSA, Ed25519, Ed448, Curve25519 and Curve448 for X.5
 |
 |{IETF}/rfc8894[RFC 8894]:
  Simple Certificate Enrollment Protocol (SCEP)
+
+|*d*
+|{IETF}/draft-uni-qsckeys-dilithium[draft-uni-qsckeys-dilithium]:
+ Quantum Safe Cryptography Key Information for CRYSTALS-Dilithium
+
+|*d*
+|{IETF}/draft-uni-qsckeys-falcon[draft-uni-qsckeys-falcon]:
+ Quantum Safe Cryptography Key Information for FALCON
+
+|*x*
+|{IETF}/draft-uni-qsckeys-sphincsplus[draft-uni-qsckeys-sphincsplus]:
+ Quantum Safe Cryptography Key Information for SPHINCS-PLUS
 |===
 
 == EAP

--- a/docs/modules/ROOT/pages/features/ipcomp.adoc
+++ b/docs/modules/ROOT/pages/features/ipcomp.adoc
@@ -2,7 +2,7 @@
 
 :IETF:    https://datatracker.ietf.org/doc/html
 :RFC3173: {IETF}/rfc3173
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 
 IP Payload Compression (IPComp) is a protocol that allows compressing the content
 of IP packets. It's defined in {RFC3173}[RFC 3173].

--- a/docs/modules/ROOT/pages/features/routeBasedVpn.adoc
+++ b/docs/modules/ROOT/pages/features/routeBasedVpn.adoc
@@ -1,6 +1,6 @@
 = Route-based VPN
 
-:TESTS:    https://www.strongswan.org/testing/testresults
+:TESTS:    https://www.strongswan.org/testing/testresults6
 :EXGRE:    {TESTS}/route-based/net2net-gre
 :EXVTI:    {TESTS}/route-based/net2net-vti
 :EXXFRM:   {TESTS}/route-based/net2net-xfrmi

--- a/docs/modules/ROOT/pages/features/vip.adoc
+++ b/docs/modules/ROOT/pages/features/vip.adoc
@@ -1,6 +1,6 @@
 = Virtual IP Addresses
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 :EX:    {TESTS}/ikev2/ip-two-pools-v4v6
 
 IKEv1 and IKEv2 both know the concept of *virtual IP* addresses. This means that

--- a/docs/modules/ROOT/pages/install/autoconf.adoc
+++ b/docs/modules/ROOT/pages/install/autoconf.adoc
@@ -1,10 +1,10 @@
 = Autoconf Options
 
-:BLISS:     https://eprint.iacr.org/2017/490.pdf
 :BOTAN:     https://botan.randombit.net/
 :GMP:       https://gmplib.org/
 :NISTPQC:   https://csrc.nist.gov/projects/post-quantum-cryptography
 :OPENSSL:   https://openssl.org/
+:LIBOQS:    https://github.com/open-quantum-safe/liboqs
 :PQ:        https://github.com/strongX509/docker/tree/master/pq-strongswan
 :TKM:       https://www.codelabs.ch/tkm/
 :UNBOUND:   https://www.nlnetlabs.nl/documentation/unbound/libunbound/
@@ -61,6 +61,9 @@ plugins.
 |xref:plugins/addrblock.adoc[--enable-addrblock]             |
 |enable {RFC3779}[RFC 3779] address block constraint support plugin
 
+|--enable-aes                                                |
+|enable AES software implementation plugin
+
 |--enable-aesni                                              |5.3.1
 |enable Intel AES-NI crypto plugin
 
@@ -94,14 +97,6 @@ plugins.
 |--enable-bfd-backtraces                                     |5.0.1
 |use binutil's libbfd to resolve backtraces for memory leaks and segfaults
 
-|--enable-bliss                                              |5.2.2
-|enable deprecated Bimodal Lattice Signature Scheme (BLISS) software
- implementation plugin. Since a {BLISS}[side-channel attack] on our BLISS
- implementation has been reported, please use the NIST PQC (Post-Quantum
- Cryptography) {NISTPQC}/selected-algorithms-2022[Selected Algorithms] and
- {NISTPQC}/round-4-submissions[Round 4 Submissions] signature algorithms offered
- by the post-quantum {PQ}[strongSwan 6.0] version instead.
-
 |--enable-blowfish                                           |
 |enable Blowfish software implementation plugin
 
@@ -129,6 +124,9 @@ plugins.
 |xref:plugins/connmark.adoc[--enable-connmark]               |5.3.0
 |enable conntrack based marks to select return path SA
 
+|--enable-curve25519                                         |5.5.2
+|enable plugin providing X25519 DH group and Ed25519 public key authentication
+
 |xref:plugins/counters.adoc[--enable-counters]               |5.6.1
 |enable plugin that collects several performance counters
 
@@ -150,6 +148,10 @@ plugins.
 |--enable-dbghelp-backtraces                                 |5.2.0
 |use dbghlp.dll on Windows to create and print backtraces for memory leaks and
  segfaults
+
+|--enable-des                                                |
+|enable DES/3DES software implementation plugin
+
 
 |xref:plugins/dhcp.adoc[--enable-dhcp]                       |
 |enable DHCP based attribute provider plugin
@@ -236,18 +238,36 @@ plugins.
 |--enable-files                                              |5.3.0
 |enable simple `file://` URI fetcher
 
+|--enable-fips-prf                                           |
+|enable FIPS PRF software implementation plugin. Required for `*eap-aka*` and
+ `*eap-sim*` plugins.
+
 |xref:plugins/forecast.adoc[--enable-forecast]               |5.3.0
 |enable plugin that forwards broadcast/multicast messages
+
+|--enable-frodo                                              |6.0
+|enable FrodoKEM post-quantum key exchange method plugin
+
 
 |xref:devs/fuzzing.adoc[--enable-fuzzing]                    |5.5.3
 |enable fuzzing scripts (found in directory `fuzz` and intended for use on the
  OSS-Fuzz infrastructure)
+
+|--enable-gcm                                                |
+|enable GCM AEAD wrapper crypto plugin
 
 |--enable-gcrypt                                             |
 |enable gcrypt plugin. Requires the GNU *libgcrypt* library
 
 |--enable-git-version                                        |
 |use output of `git describe` as version information in executables
+
+|--enable-gmp                                                |
+|enable {GMP}[GNU Multi Precision] based public key cryptography
+ implementation plugin. Requires `libgmp` library.
+
+|--enable-hmac                                               |
+|enable HMAC crypto implementation plugin
 
 |xref:plugins/ha.adoc[--enable-ha]                           |
 |enable xref:features/highAvailability.adoc[high availability] cluster plugin
@@ -346,7 +366,10 @@ plugins.
 |build the deprecated strongSwan manager web application
 
 |--enable-md4                                                |
-|enable MD4 software implementation plugin. Required for `eap-mschapv2` plugin
+|enable MD4 software implementation plugin. Required for `*eap-mschapv2*` plugin
+
+|--enable-md5                                                |
+|enable MD5 software implementation plugin
 
 |--enable-medcli                                             |
 |enable deprecated mediation client web front end and daemon plugin
@@ -361,25 +384,18 @@ plugins.
 |enable MGF1 software implementation plugin
 
 |--enable-monolithic                                         |
-|build monolithic versions of `libstrongswan` and `libcharon` that include
+|build monolithic versions of `*libstrongswan*` and `*libcharon*` that include
  all enabled plugins
 
 |--enable-mysql                                              |
 |enable MySQL database support. Requires `libmysqlclient_r`
 
-|--enable-newhope                                            |5.5.1
-|enable deprecated NewHope post-quantum key exchange plugin.
- Use the post-quantum {PQ}[strongSwan 6.0] version instead
-
 |--enable-nm                                                 |
 |enable xref:features/networkManager.adoc[NetworkManager] backend
 
-|--enable-ntru                                               |5.1.2
-|enable deprecated `NTRUEncrypt` key exchange plugin.
- Use the post-quantum {PQ}[strongSwan 6.0] version instead
-
-|--enable-openssl                                            |
-|enable [OpenSSL] crypto plugin. Requires `libcrypto` library
+|--enable-oqs                                                |6.0
+|enable oqs post-quantum key exchange methods and signatures plugin.
+ Requires the {LIBOQS}[`*liboqs*`] library
 
 |--enable-osx-attr                                           |5.1.0
 |enable macOS SystemConfiguration attribute handler
@@ -401,6 +417,9 @@ plugins.
 |xref:plugins/pkcs11.adoc[--enable-pkcs11]                   |
 |enable PKCS#11 crypto token support plugin
 
+|--enable-pkcs12                                             |5.1.0
+|enable PKCS#12 container support plugin
+
 |--enable-python-eggs                                        |5.3.0
 |enable build of provided python eggs e.g. for the
  xref:plugins/vici.adoc[`*vici*`] protocol
@@ -410,6 +429,9 @@ plugins.
 
 |xref:plugins/radattr.adoc[--enable-radattr]                 |
 |enable plugin to inject and process custom RADIUS attributes as IKEv2 client
+
+|--enable-rc2                                                |5.1.0
+|enable RC2 software implementation plugin. Required for `*pkcs12*` plugin
 
 |--enable-rdrand                                             |
 |enable Intel RDRAND random generator plugin
@@ -428,6 +450,12 @@ plugins.
 |xref:plugins/selinux.adoc[--enable-selinux]                 |5.9.6
 |enable SELinux support for labeled IPsec and the
  xref:plugins/selinux.adoc[selinux] plugin
+
+|--enable-sha1                                               |
+|enable SHA-1 software implementation plugin
+
+|--enable-sha2                                               |
+|enable SHA-256/SHA-384/SHA-512 software implementation plugin
 
 |--enable-sha3                                               |5.3.4
 |enable SHA3 and SHAKE software implementation plugin
@@ -451,6 +479,9 @@ plugins.
 
 |--enable-sqlite                                             |
 |enable SQLite database support. Requires `libsqlite3` library
+
+|--enable-stroke                                             |
+|enable legacy `stroke` configuration backend for `charon` daemon
 
 |--enable-svc                                                |5.2.0
 |enable xref:daemons/charon-svc.adoc[charon Windows service]
@@ -550,9 +581,6 @@ specific plugins.
 |===
 |Option |Since{SINCE_Ref} |Description
 
-|--disable-aes                                                |
-|disable default AES software implementation plugin
-
 |xref:plugins/attr.adoc[--disable-attr]                       |
 |disable xref:config/strongswanConf.adoc[`*strongswan.conf*`] based
  configuration of DNS and WINS server attributesfootnote:[
@@ -568,34 +596,15 @@ specific plugins.
 |xref:plugins/constraints.adoc[--disable-constraints]         |
 |disable advanced X.509 constraint checking plugin
 
-|--disable-curve25519                                         |5.5.2
-|disable plugin providing X25519 DH group and Ed25519 public key authentication
-
 |--disable-defaults                                           |5.0.3
 |disable all features that are enabled by default. Basically it's short for
  removing all options listed in this section.
-
-|--disable-des                                                |
-|disable default DES/3DES software implementation plugin
 
 |--disable-dnskey                                             |
 |disable {RFC4034}[DNS Resource Records] key decoding plugin
 
 |--disable-drgb                                               |5.8.2
 |disable the NIST Deterministic Random Bit Generator plugin
-
-|--disable-fips-prf                                           |
-|disable default FIPS PRF software implementation plugin
-
-|--disable-gcm                                                |
-|disable GCM AEAD wrapper crypto plugin (was disabled by default prior to 5.9.8)
-
-|--disable-gmp                                                |
-|disable default {GMP}[GNU Multi Precision] based public key cryptography
- implementation plugin. Requires `libgmp` library.
-
-|--disable-hmac                                               |
-|disable default HMAC crypto implementation plugin
 
 |--disable-ikev1                                              |
 |disable IKEv1 protocol support in `charon` daemon
@@ -612,11 +621,11 @@ specific plugins.
 |--disable-load-warning                                       |
 |disable the `charon` plugin load option warning in starter
 
-|--disable-md5                                                |
-|disable default MD5 software implementation plugin
-
 |--disable-nonce                                              |
 |disable nonce generation plugin
+
+|--disable-openssl                                            |
+|disable default {OPENSSL}[OpenSSL] crypto plugin. Requires the `*libcrypto*` library
 
 |--disable-pem                                                |
 |disable PEM decoding plugin
@@ -633,9 +642,6 @@ specific plugins.
 |--disable-pkcs8                                              |
 |disable PKCS#8 private key decoding plugin
 
-|--disable-pkcs12                                             |5.1.0
-|disable PKCS#12 container support plugin
-
 |xref:pki/pki.adoc[--disable-pki]                             |5.2.0
 |disable xref:pki/pki.adoc[`*pki*`] public key and certificate utility
 
@@ -644,9 +650,6 @@ specific plugins.
 
 |--disable-random                                             |
 |disable default RNG implementation using the raw `/dev/[u]random` devices
-
-|--disable-rc2                                                |5.1.0
-|disable RC2 software implementation plugin
 
 |xref:plugins/resolve.adoc[--disable-resolve]                 |
 |disable writing DNS information received via configuration payload to
@@ -658,20 +661,11 @@ specific plugins.
 |--disable-scripts                                            |
 |disable the build of additional utilities found in `scripts` directory
 
-|--disable-sha1                                               |
-|disable default SHA-1 software implementation plugin
-
-|--disable-sha2                                               |
-|disable default SHA-256/SHA-384/SHA-512 software implementation plugin
-
 |--disable-socket-default                                     |
 |disable default socket implementation for `charon` daemon
 
 |--disable-sshkey                                             |5.1.0
 |disable SSH key decoding plugin
-
-|--disable-stroke                                             |
-|disable legacy `stroke` configuration backend for `charon` daemon
 
 |xref:swanctl/swanctl.adoc[--disable-swanctl]                 |5.2.0
 |disable xref:swanctl/swanctl.adoc[`*swanctl*`] configuration and control tool

--- a/docs/modules/ROOT/pages/os/androidVpnClientProfiles.adoc
+++ b/docs/modules/ROOT/pages/os/androidVpnClientProfiles.adoc
@@ -128,7 +128,7 @@ are defined:
 |      |`port`
 |Optional server port (default is `*500*`)
 
-|      |`rid`
+|      |`id`
 |Optional IKE identity of the server. If this is not configured it defaults to
  `*addr*` and no `*IDr*` is sent in the IKE_AUTH request
 

--- a/docs/modules/ROOT/pages/plugins/addrblock.adoc
+++ b/docs/modules/ROOT/pages/plugins/addrblock.adoc
@@ -1,6 +1,6 @@
 = addrblock Plugin
 
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 :EX:      {TESTS}/ikev2/net2net-rfc3779
 :RFC3779: https://datatracker.ietf.org/doc/html/rfc3779
 

--- a/docs/modules/ROOT/pages/plugins/connmark.adoc
+++ b/docs/modules/ROOT/pages/plugins/connmark.adoc
@@ -1,7 +1,7 @@
 = connmark Plugin
 
 :XL2TPD: https://github.com/xelerance/xl2tpd/issues/82
-:TESTS:  https://www.strongswan.org/testing/testresults
+:TESTS:  https://www.strongswan.org/testing/testresults6
 :EX:     {TESTS}/ikev2/host2host-transport-connmark
 
 == Purpose

--- a/docs/modules/ROOT/pages/plugins/eap-dynamic.adoc
+++ b/docs/modules/ROOT/pages/plugins/eap-dynamic.adoc
@@ -1,6 +1,6 @@
 = eap-dynamic Plugin
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 :EX:    {TESTS}/ikev2/rw-eap-dynamic
 
 == Purpose

--- a/docs/modules/ROOT/pages/plugins/eap-radius.adoc
+++ b/docs/modules/ROOT/pages/plugins/eap-radius.adoc
@@ -10,7 +10,7 @@
 :RFC4478: {IETF}/rfc4478
 :RFC5176: {IETF}/rfc5176
 :RFC6911: {IETF}/rfc6911
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 :EX1:     {TESTS}/ikev2/rw-eap-framed-ip-radius
 :EX2:     {TESTS}/ikev2/rw-eap-md5-class-radius
 :EX3:     {TESTS}/ikev2/rw-radius-accounting

--- a/docs/modules/ROOT/pages/plugins/eap-tls.adoc
+++ b/docs/modules/ROOT/pages/plugins/eap-tls.adoc
@@ -1,6 +1,6 @@
 = eap-tls Plugin
 
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 :EX1:     {TESTS}/ikev2/rw-eap-tls-only
 :EX2:     {TESTS}/ikev2/rw-eap-tls-radius
 

--- a/docs/modules/ROOT/pages/plugins/forecast.adoc
+++ b/docs/modules/ROOT/pages/plugins/forecast.adoc
@@ -1,6 +1,6 @@
 = forecast Plugin
 
-:TESTS: https://www.strongswan.org/testing/testresults
+:TESTS: https://www.strongswan.org/testing/testresults6
 :EX:    {TESTS}/ikev2/forecast
 
 == Purpose

--- a/docs/modules/ROOT/pages/plugins/kernel-libipsec.adoc
+++ b/docs/modules/ROOT/pages/plugins/kernel-libipsec.adoc
@@ -2,7 +2,7 @@
 
 :GITHUB: https://github.com/strongswan/strongswan/blob/master
 :SYSCTL: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
-:TESTS:  https://www.strongswan.org/testing/testresults
+:TESTS:  https://www.strongswan.org/testing/testresults6
 :EX1:    {TESTS}/libipsec/net2net-cert
 :EX2:    {TESTS}/libipsec/host2host-cert
 

--- a/docs/modules/ROOT/pages/plugins/plugins.adoc
+++ b/docs/modules/ROOT/pages/plugins/plugins.adoc
@@ -13,6 +13,7 @@ for specific needs.
 :GCRYPT:    https://gnupg.org/software/libgcrypt/
 :GMP:       https://gmplib.org/
 :OPENSSL:   https://openssl.org/
+:LIBOQS:    https://github.com/open-quantum-safe/liboqs
 :UNBOUND:   https://www.nlnetlabs.nl/documentation/unbound/libunbound/
 :WIRESHARK: https://www.wireshark.org/
 :WOLFSSL:   https://github.com/wolfSSL/wolfssl
@@ -35,7 +36,7 @@ for specific needs.
 |acert                                    | |s
 |Support of X.509 attribute certificates
 
-|aes                                      |x|s
+|aes                                      | |s
 |AES-128/192/256 cipher software implementation
 
 |aesni                                    | |s
@@ -46,9 +47,6 @@ for specific needs.
 
 |agent                                    | |s
 |RSA/ECDSA private key backend connecting to ssh-agent
-
-|bliss                                    | |e
-|Bimodal Lattice Signature Scheme (BLISS) post-quantum computer signature scheme
 
 |blowfish                                 | |s
 |Blowfish cipher software implementation
@@ -74,24 +72,26 @@ for specific needs.
 |xref:./curl.adoc[curl]                   | |s
 |libcurl based HTTP/FTP fetcher
 
-|curve25519                               |x|s
+|curve25519                               | |s
 |X25519 DH group and Ed25519 public key authentication
 
-|des                                      |x|s
+|des                                      | |s
 |DES/3DES cipher software implementation
 
 |dnskey                                   |x|s
 |Parse {RFC4034}[DNS] public keys
 
 |drbg                                     |x|s
-|NIST Deterministic Random Bit Generator based on AES-CTR and HMAC-SHA2 modes.
- Required by the ntru plugins
+|NIST Deterministic Random Bit Generator based on AES-CTR and HMAC-SHA2 modes
 
 |files                                    | |s
 |Fetcher for local file:// URIs
 
-|fips-prf                                 |x|s
+|fips-prf                                 | |s
 |PRF specified by FIPS, used by EAP-SIM/AKA algorithms
+
+|frodo                                    | |e
+|FrodoKEM post quantum safe key exchange method
 
 |gcm                                      | |s
 |GCM cipher mode wrapper
@@ -99,10 +99,10 @@ for specific needs.
 |gcrypt                                   | |s
 |Crypto backend based on {GCRYPT}[libgcrypt]
 
-|gmp                                      |x|s
+|gmp                                      | |s
 |RSA/DH crypto backend based on {GMP}[libgmp]
 
-|hmac                                     |x|s
+|hmac                                     | |s
 |HMAC wrapper using various hashers
 
 |kdf                                      |x|s
@@ -117,7 +117,7 @@ for specific needs.
 |md4                                      | |s
 |MD4 hasher software implementation
 
-|md5                                      |x|s
+|md5                                      | |s
 |MD5 hasher software implementation
 
 |mgf1                                     | |s
@@ -126,17 +126,14 @@ for specific needs.
 |mysql                                    | |s
 |MySQL database backend based on libmysqlclient
 
-|newhope                                  | |e
-|Key exchange based on post-quantum computer New Hope algorithm
-
 |nonce                                    |x|s
 |Default nonce generation plugin
 
-|ntru                                     | |e
-|Key exchange based on post-quantum computer NTRU encryption
-
-|openssl                                  | |s
+|openssl                                  |x|s
 |Crypto backend based on the {OPENSSL}[OpenSSL] library
+
+|oqs                                      | |e
+|Open quantum safe plugin based on the {LIBOQS}[`*liboqs*`] library
 
 |padlock                                  | |e
 |VIA padlock crypto backend, provides AES128/SHA1
@@ -159,7 +156,7 @@ for specific needs.
 |xref:./pkcs11.adoc[pkcs11]               | |s
 |PKCS#11 smart card backend
 
-|pkcs12                                   |x|s
+|pkcs12                                   ||s
 |PKCS#12 decoding routines
 
 |pubkey                                   |x|s
@@ -168,7 +165,7 @@ for specific needs.
 |random                                   |x|s
 |RNG reading from /dev/[u]random
 
-|rc2                                      |x|s
+|rc2                                      | |s
 |RC2 cipher software implementation
 
 |rdrand                                   | |e
@@ -177,10 +174,10 @@ for specific needs.
 |revocation                               |x|s
 |X.509 CRL/OCSP revocation checking
 
-|sha1                                     |x|s
+|sha1                                     | |s
 |SHA1 hasher software implementation
 
-|sha2                                     |x|s
+|sha2                                     | |s
 |SHA-2 hasher software implementation
 
 |sha3                                     | |s
@@ -403,7 +400,7 @@ WinHTTP based HTTP/HTTPS fetcher for Windows platform
 |xref:./sql.adoc[sql]                     | |s
 |SQL configuration backend reading configurations/credentials from a database
 
-|stroke                                   |x|s
+|stroke                                   | |s
 |Deprecated stroke configuration/control backend, to use with ipsec script and starter
 
 |xref:./tnc-ifmap.adoc[tnc-ifmap]         | |s
@@ -481,14 +478,11 @@ WinHTTP based HTTP/HTTPS fetcher for Windows platform
 
 == Default Plugins
 
-The following 36 plugins are built and loaded by default:
+The following 25 plugins are built and loaded by default:
 
 [cols="5,1,1,20"]
 |===
 |Plugin Name                              |E{E_ref}|S{S_ref}|Description
-
-|aes                                      |x|s
-|AES-128/192/256 cipher software implementation
 
 |cmac                                     |x|s
 |CMAC cipher mode wrapper
@@ -496,36 +490,21 @@ The following 36 plugins are built and loaded by default:
 |xref:./constraints.adoc[constraints]     |x|s
 |X.509 certificate advanced constraint checking
 
-|curve25519                               |x|s
-|X25519 DH group and Ed25519 public key authentication
-
-|des                                      |x|s
-|DES/3DES cipher software implementation
-
 |dnskey                                   |x|s
 |Parse {RFC4034}[RFC 4034] public keys
 
 |drbg                                     |x|s
 |NIST Deterministic Random Bit Generator based on AES-CTR and HMAC-SHA2 modes.
- Required by the `*gmp*` and `*ntru*` plugins
-
-|fips-prf                                 |x|s
-|PRF specified by FIPS, used by EAP-SIM/AKA algorithms
-
-|gmp                                      |x|s
-|RSA/DH crypto backend based on {GMP}[libgmp]
-
-|hmac                                     |x|s
-|HMAC wrapper using various hashers
+ Required by the `*gmp*` plugin
 
 |kdf                                      |x|s
 |IKEv2 key derivation wrapper using various PRFs
 
-|md5                                      |x|s
-|MD5 hasher software implementation
-
 |nonce                                    |x|s
 |Default nonce generation plugin
+
+|openssl                                  |x|s
+|Crypto backend based on the {OPENSSL}[OpenSSL] library
 
 |pem                                      |x|s
 |PEM encoding/decoding routines
@@ -542,26 +521,14 @@ The following 36 plugins are built and loaded by default:
 |pkcs8                                    |x|s
 |PKCS#8 decoding routines
 
-|pkcs12                                   |x|s
-|PKCS#12 decoding routines
-
 |pubkey                                   |x|s
 |Wrapper to handle raw public keys as trusted certificates
 
 |random                                   |x|s
 |RNG reading from /dev/[u]random
 
-|rc2                                      |x|s
-|RC2 cipher software implementation
-
 |revocation                               |x|s
 |X.509 CRL/OCSP revocation checking
-
-|sha1                                     |x|s
-|SHA1 hasher software implementation
-
-|sha2                                     |x|s
-|SHA-2 hasher software implementation
 
 |sshkey                                   |x|s
 |SSH key decoding routines
@@ -572,7 +539,7 @@ The following 36 plugins are built and loaded by default:
 |xcbc                                     |x|s
 |XCBC wrapper using various ciphers
 
-|*libstrongswan*                          |28|
+|*libstrongswan*                          |18|
 |
 
 |xref:./attr.adoc[attr]                   |x|s
@@ -587,9 +554,6 @@ The following 36 plugins are built and loaded by default:
 |socket-default                           |x|s
 |Default socket implementation for IKE messages
 
-|stroke                                   |x|s
-|Deprecated stroke configuration/control backend, to use with ipsec script and starter
-
 |xref:./updown.adoc[updown]               |x|s
 |Shell script invocation during tunnel up/down events
 
@@ -599,6 +563,6 @@ The following 36 plugins are built and loaded by default:
 |xauth-generic                            |x|s
 |Generic XAuth backend that provides passwords from credential sets
 
-|*libcharon*                              |8|
+|*libcharon*                              |7|
 |
 |===

--- a/docs/modules/ROOT/pages/plugins/xauth-eap.adoc
+++ b/docs/modules/ROOT/pages/plugins/xauth-eap.adoc
@@ -1,6 +1,6 @@
 = xauth-eap Plugin
 
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 :EX:     {TESTS}/ikev1/xauth-rsa-eap-md5-radius
 
 == Purpose

--- a/docs/modules/ROOT/pages/support/faq.adoc
+++ b/docs/modules/ROOT/pages/support/faq.adoc
@@ -8,7 +8,7 @@
 :RFC6125:   {IETF}/rfc6125
 :RFC7383:   {IETF}/rfc7383
 :MITM:      https://en.wikipedia.org/wiki/Man-in-the-middle_attack
-:TESTS:     https://www.strongswan.org/testing/testresults
+:TESTS:     https://www.strongswan.org/testing/testresults6
 
 == General Questions
 

--- a/docs/modules/ROOT/pages/swanctl/swanctlConf.adoc
+++ b/docs/modules/ROOT/pages/swanctl/swanctlConf.adoc
@@ -12,7 +12,7 @@
 :RFC7383: {IETF}/rfc7383
 :RFC7427: {IETF}/rfc7427
 :RFC8784: {IETF}/rfc8784
-:TESTS:   https://www.strongswan.org/testing/testresults
+:TESTS:   https://www.strongswan.org/testing/testresults6
 
 == Overview
 


### PR DESCRIPTION
By trial and error it was discovered, that the `remote.id` key shall be used to set the server identity.