### PR TITLE
Update introduction.adoc

### DIFF
--- a/docs/modules/ROOT/pages/howtos/introduction.adoc
+++ b/docs/modules/ROOT/pages/howtos/introduction.adoc
@@ -97,7 +97,7 @@ This is a security feature.
 
 The actual {IPSEC}[IPsec traffic] is not handled by *strongSwan* but will be relegated
 to the network and IPsec stack of the operating system kernel. *strongSwan* installs
-the negotiated IPsec SAs and SPs into the kernel by using a platform-dependent
+the negotiated IPsec SAs and security policies (SPs) into the kernel by using a platform-dependent
 *kernel interface*.
 
 The mentioned distinction between policies and SAs often leads to *misconceptions*.


### PR DESCRIPTION
In line 100 the acronym SP is used for the first time without any context.  I assume this is meant to mean security policies.  I propose including the following changes for individuals who may not immediately have the reflex to associate SP with security policies.