### PR TITLE
fix example 'Creation of two VTI Devices'

### DIFF
--- a/docs/modules/ROOT/pages/features/routeBasedVpn.adoc
+++ b/docs/modules/ROOT/pages/features/routeBasedVpn.adoc
@@ -294,7 +294,7 @@ All of this also works for IPv6.
 ==== Example: Creation of two VTI Devices (vti0 and ipsec0)
 ----
 ip tunnel add vti0   local 192.168.0.1 remote 192.168.0.2 mode vti key 42
-ip tunnel add ipsec0 local 192.168.0.1 remote 192.168.0.2 mode vti key 0x01000201
+ip tunnel add ipsec0 local 192.168.0.1 remote 192.168.0.3 mode vti key 0x01000201
 sysctl -w net.ipv4.conf.vti0.disable_policy=1
 ip link set vti0 up
 ip route add 10.1.0.0/16 dev vti0


### PR DESCRIPTION
Kernel refuses to add tunnel 'ipsec0', because it has the same local and remote as 'vti0'.

This also matches what is written in 'Connection-specific VTI Devices':
 "The kernel rejects the creation of a VTI device if the remote and local addresses are already in use by another VTI device."