### PR TITLE
Add the "Windows split-tunnel with DHCP" example.

### DIFF
--- a/docs/modules/ROOT/pages/howtos/forwarding.adoc
+++ b/docs/modules/ROOT/pages/howtos/forwarding.adoc
@@ -179,7 +179,9 @@ Windows 10 ::
   Windows 7, i.e. the virtual IP has to be from the remote subnet or routes have
   to be added manually, e.g. via the
   {VPNCLIENT}/Add-VpnConnectionRoute?view=win10-ps[Add-VpnConnectionRoute] PowerShell
-  command. To tunnel all traffic via VPN instead, split tunneling has to be disabled
+  command,
+  or using DHCP (see xref:interop/windowsClients.adoc#split_routing_since_windows_10[Windows clients documentation]).
+  To tunnel all traffic via VPN instead, split tunneling has to be disabled
   explicitly, either by enabling the _Use default gateway on remote network_
   setting described above or by using the following PowerShell command
 +

--- a/docs/modules/ROOT/pages/interop/windowsClients.adoc
+++ b/docs/modules/ROOT/pages/interop/windowsClients.adoc
@@ -187,17 +187,19 @@ on the strongSwan VPN gateway.
 === IKEv2 Fragmentation
 
 IKEv2 fragmentation is supported since the v1803 release of Windows 10 and Windows
-Server. All versions of Windows also support the proprietary IKEv1 fragmentation.
+Server.All versions of Windows also support the proprietary IKEv1 fragmentation.
 
+[#split_routing_since_windows_10]
 === Split Routing since Windows 10
 
 Microsoft changed the Windows 10 VPN routing behavior for new VPN connections.
 Option "Use default gateway on remote network option" in the Advanced TCP/IP settings
 of the VPN connection is now disabled by default but can be enabled if desired.
-Fortunately Windows sends a DHCP request upon connection and add routes supplied
+Fortunately Windows sends a `DHCPINFORM` request upon connection and add routes supplied
 in option `*249*` of the DHCP reply.
+To use DHCP, include `255.255.255.255/32` to your `local_ts` to enable broadcast.
 
-Sample configuration file for dnsmasq:
+Sample configuration file for dnsmasq to forward *all* traffic via gateway:
 ----
 dhcp-vendorclass=set:msipsec,MSFT 5.0
 dhcp-range=tag:msipsec,192.168.103.0,static
@@ -208,6 +210,23 @@ where `*192.168.103.0*` is your (internal) network. It pushes two separate route
 which cover the entire IPv4 range. Gateway could be anything (set to `*0.0.0.0*`
 in an example) as it is ignored by Windows. Note that you can't ignore DHCP routes
 in Windows.
+
+To route only specific networks, list them in `*249*` attribute.
+In this example we route `192.168.101.0/24` via our gateway:
+
+dnsmasq:
+----
+dhcp-vendorclass=set:msipsec,MSFT 5.0
+dhcp-range=tag:msipsec,192.168.103.0,static
+dhcp-option=tag:msipsec,6
+dhcp-option=tag:msipsec,249, 192.168.101/24, 0.0.0.0
+----
+
+swanctl:
+----
+# '192.168.101.0/24' is an office network to be added to the client's routing table
+local_ts = 192.168.101.0/24,  255.255.255.255/32
+----
 
 === IPv6
 


### PR DESCRIPTION
See: https://github.com/strongswan/strongswan/discussions/2611

* Add a link from general forwarding doc to the Windows-specific page
* Provide an example that forwards specific networks
* Mention broadcast in traffic selectors which is required for DHCP to work